### PR TITLE
adjust webpack runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,12 +52,14 @@ export default {
     if (query.publicPath) {
       webpackConfig.output.publicPath = query.publicPath;
     }
+
+    const compiler = webpack(webpackConfig);
+    this.set('compiler', compiler);
   },
 
   'middleware'() {
     const { verbose } = this.query;
-    const compiler = webpack(webpackConfig);
-    this.set('compiler', compiler);
+    const compiler = this.get('compiler', compiler);
     compiler.plugin('done', function doneHandler(stats) {
       if (verbose || stats.hasErrors()) {
         console.log(stats.toString({colors: true}));


### PR DESCRIPTION
调整了 webpack 实例创建的时机

用以满足可以在 dora 插件内新增 webpack 插件首次遍生效。
