### PR TITLE
修改 devtool 为 cheap-module-eval-source-map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default {
     }
 
     webpackConfig = getWebpackCommonConfig({ ...this, cwd });
-    webpackConfig.devtool = 'cheap-module-eval-source-map';
+    webpackConfig.devtool = 'eval-cheap-module-source-map';
     webpackConfig.plugins = webpackConfig.plugins.concat([
       new ProgressPlugin((percentage, msg) => {
         const stream = process.stderr;

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default {
     }
 
     webpackConfig = getWebpackCommonConfig({ ...this, cwd });
-    webpackConfig.devtool = '#cheap-module-source-map';
+    webpackConfig.devtool = 'cheap-module-eval-source-map';
     webpackConfig.plugins = webpackConfig.plugins.concat([
       new ProgressPlugin((percentage, msg) => {
         const stream = process.stderr;


### PR DESCRIPTION
> 参考：http://webpack.github.io/docs/configuration.html#devtool

原因如下：
1. webpack 下一个版本默认为 cheap-module-eval-source-map
2. eval 速度会快一些
3. eval 不会生成 map 文件
4. 有时 source-map 过大会导致加载失败
